### PR TITLE
Aggiungi tema scuro e gestione costo settimanale

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -74,6 +74,28 @@
     --transition-slow: 0.5s ease;
 }
 
+/* Dark mode overrides */
+body.dark-mode {
+    --bg-main: #181818;
+    --bg-sidebar: #222222;
+    --bg-content: #242424;
+    --bg-card: #2c2c2c;
+    --bg-alt: #2c2c2c;
+    --bg-input: #333333;
+    --bg-hover-light: #333333;
+    --bg-active-light: #444444;
+    --text-primary: #f1f1f1;
+    --text-secondary: #dddddd;
+    --text-tertiary: #aaaaaa;
+    --text-link: #90cdf4;
+    --text-link-hover: #63b3ed;
+    --border-color: #444444;
+    --border-color-light: #555555;
+    --border-input: #555555;
+    --accent-primary: #0d6efd;
+    --accent-primary-dark: #0b5ed7;
+}
+
 /* --- Reset & Base Styles --- */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 html { scroll-behavior: smooth; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; font-size: 100%; /* Base 16px */ }

--- a/js/config.js
+++ b/js/config.js
@@ -14,6 +14,7 @@
         DEFAULT_SETTINGS: {
             nutritionistEmail: 'TUA_EMAIL_NUTRIZIONISTA@example.com', // !! SOSTITUISCI !!
             waterGoalL: 2.0, // Default daily water goal in Liters
+            darkMode: false, // UI theme preference
         },
 
         // Application constants
@@ -34,7 +35,7 @@
             WORKOUT_DATA_PREFIX: 'wellnessPro_WorkoutData_', // Append Day Name
             DIET_PLAN: 'wellnessPro_EditableDietPlan_v1', // Versioned key
             SETTINGS: 'wellnessPro_Settings_v1',          // Versioned key
-            // Note: Removed weekly cost as separate key, can derive from tracking or keep if needed
+            WEEKLY_COST: 'wellnessPro_WeeklyCost_v1',     // Weekly cost value
         },
 
         // Default Editable Diet Plan (Structure from V8.1)

--- a/js/dataManager.js
+++ b/js/dataManager.js
@@ -229,6 +229,24 @@
              return _setItem(app.config.LOCALSTORAGE_KEYS.SETTINGS, settingsToSave);
         },
 
+        // -- Weekly Cost --
+        loadWeeklyCost: function() {
+            const stored = _getItem(app.config.LOCALSTORAGE_KEYS.WEEKLY_COST);
+            return stored !== null && stored !== undefined ? stored : '';
+        },
+
+        saveWeeklyCost: function(cost) {
+            if (cost === undefined || cost === null || cost === '') {
+                return _setItem(app.config.LOCALSTORAGE_KEYS.WEEKLY_COST, '');
+            }
+            const parsed = parseFloat(cost);
+            if (isNaN(parsed)) {
+                console.error('Invalid cost value provided for saveWeeklyCost');
+                return false;
+            }
+            return _setItem(app.config.LOCALSTORAGE_KEYS.WEEKLY_COST, parsed);
+        },
+
         // -- Data Reset Utility --
         resetAllData: function() {
             let success = true;
@@ -238,6 +256,7 @@
             const keysToRemove = [
                 app.config.LOCALSTORAGE_KEYS.DIET_PLAN,
                 app.config.LOCALSTORAGE_KEYS.SETTINGS,
+                app.config.LOCALSTORAGE_KEYS.WEEKLY_COST,
             ];
 
             app.config.DAYS_OF_WEEK.forEach(day => {

--- a/js/main.js
+++ b/js/main.js
@@ -50,6 +50,10 @@ window.app = window.app || {};
         // --- Initialize UI Elements ---
         app.ui.setAppVersion(app.config.APP_VERSION);
 
+        // Apply theme based on saved settings
+        const initSettings = app.dataManager.loadSettings();
+        app.ui.applyDarkMode(initSettings.darkMode);
+
 
         // --- Initialize Router ---
         // The router will handle the initial route based on the URL hash

--- a/js/sections/settings.js
+++ b/js/sections/settings.js
@@ -27,6 +27,7 @@
 
         const emailInput = document.getElementById('nutritionistEmail');
         const waterGoalInput = document.getElementById('waterGoal');
+        const darkModeInput = document.getElementById('darkMode');
         let changed = false;
 
         if (emailInput && currentSettings.nutritionistEmail !== emailInput.value.trim()) {
@@ -39,6 +40,13 @@
              if (currentGoal !== newGoal) {
                  changed = true;
             }
+        }
+        if (darkModeInput) {
+            if (!!currentSettings.darkMode !== darkModeInput.checked) {
+                changed = true;
+            }
+            // Preview theme immediately
+            app.ui.applyDarkMode(darkModeInput.checked);
         }
         // Add checks for other settings fields here...
 
@@ -57,8 +65,10 @@
          // Update the currentSettings object with values from the UI *before* saving
          const emailInput = document.getElementById('nutritionistEmail');
          const waterGoalInput = document.getElementById('waterGoal');
+         const darkModeInput = document.getElementById('darkMode');
          if (emailInput) currentSettings.nutritionistEmail = emailInput.value.trim();
          if (waterGoalInput) currentSettings.waterGoalL = parseFloat(waterGoalInput.value) || app.config.DEFAULT_SETTINGS.waterGoalL;
+         if (darkModeInput) currentSettings.darkMode = darkModeInput.checked;
          // Update currentSettings with other fields here...
 
 
@@ -84,11 +94,12 @@
                      success = app.dataManager.saveSettings(currentSettings); // Save the updated object
                      if (success) {
                          app.ui.showStatusMessage("Impostazioni salvate.", 'success');
-                         hasChanges = false; // Reset flag after successful save
-                         _updateSaveButtonState(); // Update button state
-                         // Update the global config if needed (e.g., for mailto) - might require app reload for full effect
-                         app.config.NUTRITIONIST_EMAIL = currentSettings.nutritionistEmail;
-                         console.log("Settings saved and config potentially updated in memory.");
+                        hasChanges = false; // Reset flag after successful save
+                        _updateSaveButtonState(); // Update button state
+                        // Update the global config if needed (e.g., for mailto) - might require app reload for full effect
+                        app.config.NUTRITIONIST_EMAIL = currentSettings.nutritionistEmail;
+                        app.ui.applyDarkMode(currentSettings.darkMode);
+                        console.log("Settings saved and config potentially updated in memory.");
                      } else {
                          // Error message handled by dataManager for quota issues
                           app.ui.showStatusMessage("Errore nel salvataggio delle impostazioni.", 'error');
@@ -167,6 +178,9 @@
         app.ui.showLoading('Caricamento impostazioni...');
         _loadSettings(); // Load current settings into `currentSettings`
 
+        // Apply theme immediately
+        app.ui.applyDarkMode(currentSettings.darkMode);
+
         // Handle case where settings couldn't be loaded (though _loadSettings has fallback)
         if (!currentSettings) {
              app.ui.setContent('<p class="text-danger text-center mt-5">Errore critico: Impossibile caricare le impostazioni.</p>');
@@ -204,6 +218,11 @@
                         step: '0.1', min: '0',
                         value: app.ui.sanitize(String(currentSettings.waterGoalL ?? app.config.DEFAULT_SETTINGS.waterGoalL)) // Use loaded or default, ensure string
                     })
+                ]),
+                // Dark Mode Toggle
+                app.ui.renderElement('div', { class: 'mb-3 form-check form-switch' }, [
+                    app.ui.renderElement('input', { type: 'checkbox', class: 'form-check-input', id: 'darkMode', name: 'darkMode', checked: currentSettings.darkMode ?? false }),
+                    app.ui.renderElement('label', { class: 'form-check-label', for: 'darkMode' }, 'Tema scuro')
                 ]),
                 // Add more settings fields here... Example:
                 // app.ui.renderElement('div', { class: 'mb-3 form-check form-switch' }, [

--- a/js/ui.js
+++ b/js/ui.js
@@ -442,6 +442,14 @@
             if (!(date instanceof Date)) return "";
              const options = { day: 'numeric', month: 'short' };
             return date.toLocaleDateString('it-IT', options);
+        },
+
+        /**
+         * Toggles dark mode class on the body element.
+         * @param {boolean} enabled - Whether dark mode should be enabled.
+         */
+        applyDarkMode: function(enabled) {
+            document.body.classList.toggle('dark-mode', !!enabled);
         }
 
 


### PR DESCRIPTION
## Summary
- add `darkMode` in settings and theme
- implement weekly cost storage in dataManager and config
- toggle dark theme on load and in settings
- style dark mode variables

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840b1bce8f48328b237c889bed501c9